### PR TITLE
feat: support self-hosted Firecrawl instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To configure Firecrawl MCP in Zed:
   "context_servers": {
     "mcp-server-firecrawl": {
       "settings": {
-        "firecrawl_api_key": "YOUR-API-KEY"
+        "firecrawl_api_key": "YOUR-API-KEY",
+        "firecrawl_api_url": "YOUR-API-URL" // Optional, for self-hosted instances
       }
     }
   }
@@ -27,6 +28,8 @@ To configure Firecrawl MCP in Zed:
 ```
 
 Replace `YOUR-API-KEY` with your Firecrawl API key. If you don't have one yet, create an account at [firecrawl.dev](https://www.firecrawl.dev/app/api-keys).
+
+If you're using a self-hosted Firecrawl instance, replace `YOUR-API-URL` with your instance URL. If you're using the official Firecrawl service, you can remove the `firecrawl_api_url` line.
 
 ## Agent Mode Configuration
 

--- a/configuration/default_settings.jsonc
+++ b/configuration/default_settings.jsonc
@@ -1,4 +1,6 @@
 {
   /// Your Firecrawl API key
   "firecrawl_api_key": "YOUR_FIRECRAWL_API_KEY"
+  /// Your optional Firecrawl API URL for self-hosted instances
+  // "firecrawl_api_url": "YOUR_FIRECRAWL_API_URL"
 }

--- a/configuration/installation_instructions.md
+++ b/configuration/installation_instructions.md
@@ -1,1 +1,4 @@
-To use Firecrawl's MCP, go to your [account settings](https://www.firecrawl.dev/app/api-keys) and generate an API key.
+To use Firecrawl's MCP:
+
+1. Go to your [account settings](https://www.firecrawl.dev/app/api-keys) and generate an API key.
+2. If you're using a self-hosted Firecrawl instance, you'll also need to provide your instance URL using the `firecrawl_api_url` setting.

--- a/src/mcp_server_firecrawl.rs
+++ b/src/mcp_server_firecrawl.rs
@@ -14,7 +14,8 @@ struct FirecrawlModelContextExtension;
 #[derive(Debug, Deserialize, JsonSchema)]
 struct FirecrawlContextServerSettings {
     firecrawl_api_key: String,
-    firecrawl_api_url: String,
+    #[serde(default)]
+    firecrawl_api_url: Option<String>,
 }
 
 impl zed::Extension for FirecrawlModelContextExtension {
@@ -47,10 +48,15 @@ impl zed::Extension for FirecrawlModelContextExtension {
                 .join(SERVER_PATH)
                 .to_string_lossy()
                 .to_string()],
-            env: vec![
-                ("FIRECRAWL_API_KEY".into(), settings.firecrawl_api_key),
-                ("FIRECRAWL_API_URL".into(), settings.firecrawl_api_url),
-            ],
+            env: {
+                let mut env_vars = vec![("FIRECRAWL_API_KEY".into(), settings.firecrawl_api_key)];
+
+                if let Some(api_url) = settings.firecrawl_api_url {
+                    env_vars.push(("FIRECRAWL_API_URL".into(), api_url));
+                }
+
+                env_vars
+            },
         })
     }
 

--- a/src/mcp_server_firecrawl.rs
+++ b/src/mcp_server_firecrawl.rs
@@ -14,6 +14,7 @@ struct FirecrawlModelContextExtension;
 #[derive(Debug, Deserialize, JsonSchema)]
 struct FirecrawlContextServerSettings {
     firecrawl_api_key: String,
+    firecrawl_api_url: String,
 }
 
 impl zed::Extension for FirecrawlModelContextExtension {
@@ -46,7 +47,10 @@ impl zed::Extension for FirecrawlModelContextExtension {
                 .join(SERVER_PATH)
                 .to_string_lossy()
                 .to_string()],
-            env: vec![("FIRECRAWL_API_KEY".into(), settings.firecrawl_api_key)],
+            env: vec![
+                ("FIRECRAWL_API_KEY".into(), settings.firecrawl_api_key),
+                ("FIRECRAWL_API_URL".into(), settings.firecrawl_api_url),
+            ],
         })
     }
 


### PR DESCRIPTION
Implemented support for self-hosted Firecrawl instances by supporting `FIRECRAWL_API_URL` environment variable, see https://github.com/mendableai/firecrawl-mcp-server/blob/17ed28c816e8608584e0f930b82410919e91fc0d/src/index.ts#L858

Closes https://github.com/akbxr/firecrawl-mcp-zed/issues/2